### PR TITLE
Update backup.sh

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-OPTIONS=`python /usr/local/bin/mongouri`
+OPTIONS=`python /usr/local/bin/mongouri --forceTableScan`
 BACKUP_NAME="$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz"
 
 # Run backup


### PR DESCRIPTION
the --forceTableScan option will prevent the snapshot functionality to become active, and the error 'Unrecognized field 'snapshot' will not appear for MongoDb version 4.0 and above